### PR TITLE
Fix Aidoku backup conversions containing 64-bit integers

### DIFF
--- a/lib/plist/binary.parse/index.ts
+++ b/lib/plist/binary.parse/index.ts
@@ -60,7 +60,7 @@ function readInt32(buffer: ArrayBuffer, start = 0) {
 }
 
 function readInt64(buffer: ArrayBuffer, start = 0) {
-    return new DataView(buffer).getBigInt64(start, false);
+    return Number(new DataView(buffer).getBigInt64(start, false));
 }
 
 function readInt(buffer: ArrayBuffer) {


### PR DESCRIPTION
Aidoku will occasionally generate reading progress entry values with a page number of -1. Apple's PropertyListEncoder, for some reason, encodes this as a 64-bit integer. This is being (correctly) deserialised as a BigInt, since JavaScript's 64-bit floating point Number values cannot accurately fit all values of a 64-bit integer. 

However, when the value is serialised into a Suwatte backup file using JSON.stringify, the exception `TypeError: BigInt value can't be serialized in JSON` is thrown. To avoid pulling in a JSON serialisation dependency which can properly serialise BigInts, this fix will be fully accurate for any 64-bit numbers smaller than 9,007,199,254,740,991, which seems reasonably high enough.